### PR TITLE
Simple top padding for clear href scroll view

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,7 @@ export default function Home(props) {
             </a>
           </div>
         </main>
-        <div id="info">
+        <div id="info" className={styles.infoDiv}>
           <Container className={styles.infoContainer}>
             <Row>
               {cardDetails.map((cardInfo, i) => {

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -343,6 +343,10 @@
   margin: auto;
 }
 
+.infoDiv{
+  padding-top:100px;
+}
+
 .joinUsButton_light {
   display: block;
   width: 308px;


### PR DESCRIPTION
The previous href jump to #info is hidden by the bootstrap navbar. 